### PR TITLE
Deprecated selector in `pristine-ui/index.less`

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -16,7 +16,7 @@ atom-text-editor[mini] {
   background-color: @input-background-color;
 
   &,
-  &::shadow {
+  &.editor {
     .placeholder-text {
       color: @text-color-subtle;
     }
@@ -30,7 +30,7 @@ atom-text-editor[mini] {
   }
 
   &.is-focused,
-  &.is-focused::shadow {
+  &.is-focused.editor {
     .focus();
     background-color: @input-background-color-focus;
     .selection .region {


### PR DESCRIPTION
In `pristine-ui/index.less`: 

Starting from Atom v1.13.0, the contents of `atom-text-editor` elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using `:host` and `::shadow` pseudo-selectors, and prepend all your syntax selectors with `syntax--`. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:

* `atom-text-editor[mini] .placeholder-text,
atom-text-editor[mini]::shadow .placeholder-text` => `atom-text-editor[mini] .placeholder-text,
atom-text-editor[mini].editor .placeholder-text`

* `atom-text-editor[mini] .selection .region,
atom-text-editor[mini]::shadow .selection .region` => `atom-text-editor[mini] .selection .region,
atom-text-editor[mini].editor .selection .region`

* `atom-text-editor[mini] .cursor,
atom-text-editor[mini]::shadow .cursor` => `atom-text-editor[mini] .cursor,
atom-text-editor[mini].editor .cursor`

* `atom-text-editor[mini].is-focused,
atom-text-editor[mini].is-focused::shadow` => `atom-text-editor[mini].is-focused,
atom-text-editor[mini].is-focused.editor`

* `atom-text-editor[mini].is-focused .selection .region,
atom-text-editor[mini].is-focused::shadow .selection .region` => `atom-text-editor[mini].is-focused .selection .region,
atom-text-editor[mini].is-focused.editor .selection .region`

Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible.